### PR TITLE
Change logic for image thumnail sizing

### DIFF
--- a/__tests__/imageAndLayoutHelpers.js
+++ b/__tests__/imageAndLayoutHelpers.js
@@ -1,6 +1,5 @@
 import {
   calculateScreenOrientation,
-  calculateImageListColumns,
   calculateImageDisplayDimensions,
 } from "../src/utils/helpers";
 
@@ -35,27 +34,6 @@ test("screen oriention helper function should return landscape", () => {
       screenSizes.landscapeScreen.screenHeight
     )
   ).toBe(screenSizes.landscapeScreen.screenOrientation);
-});
-
-//image list layout columns tests
-test("image list column helper should return 4 columns", () => {
-  const marginInPixels = 16;
-  expect(
-    calculateImageListColumns(
-      screenSizes.portraitScreen.screenWidth,
-      marginInPixels
-    )
-  ).toBe(4);
-});
-
-test("image list column helper should return 8 columns", () => {
-  const marginInPixels = 16;
-  expect(
-    calculateImageListColumns(
-      screenSizes.landscapeScreen.screenWidth,
-      marginInPixels
-    )
-  ).toBe(8);
 });
 
 //image resizing tests

--- a/src/components/ImageList.js
+++ b/src/components/ImageList.js
@@ -26,6 +26,10 @@ const ImageList = ({
     screenOrientation,
     8
   );
+  //for larger screens, like tablets, if the thumbnails are too big, use the webformatURL
+  const thumbnailURL =
+    imageWidthandHeight <= 150 ? "previewURL" : "webformatURL";
+
   const rowHeight = imageWidthandHeight + 2 * styles.imageThumbnail.margin;
   //header height is used to calculate the offset
   const headerHeight = 20;
@@ -100,7 +104,7 @@ const ImageList = ({
         >
           <Image
             resizeMode="cover"
-            source={{ uri: item.previewURL }}
+            source={{ uri: item[thumbnailURL] }}
             style={[
               styles.roundedBorder,
               styles.imageThumbnail,

--- a/src/components/ImageList.js
+++ b/src/components/ImageList.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { connect } from "react-redux";
 import styles from "../style/appStyles";
-import { calculateImageListColumns } from "../utils/helpers";
+import { calculateImageThumbnailWidthandHeight } from "../utils/helpers";
 import store from "../redux/store";
 import { TouchableOpacity, FlatList, Image, Text } from "react-native";
 import { updatePositionInImageList } from "../redux/actions";
@@ -14,14 +14,19 @@ const ImageList = ({
   results,
   totalHits,
   screenWidth,
+  screenOrientation,
 }) => {
   //figure out where the last position in the list was
   const indexInImageList = store.getState().indexInImageList;
   //calculate the number of columns that should be in the flatList
-  const numofColumns = calculateImageListColumns(screenWidth, 16);
-  //calculate row height from stylesheet
-  const rowHeight =
-    styles.imageThumbnail.height + 2 * styles.imageThumbnail.margin;
+  const numofColumns = screenOrientation == "portrait" ? 4 : 8;
+  //calculate the image height and width
+  const imageWidthandHeight = calculateImageThumbnailWidthandHeight(
+    screenWidth,
+    screenOrientation,
+    8
+  );
+  const rowHeight = imageWidthandHeight + 2 * styles.imageThumbnail.margin;
   //header height is used to calculate the offset
   const headerHeight = 20;
   //add a ref to the flatlist
@@ -44,7 +49,6 @@ const ImageList = ({
           headerHeight;
       }
       flatListRef.current.scrollToOffset({
-        animated: true,
         offset: offset,
       });
     }
@@ -76,7 +80,7 @@ const ImageList = ({
       ListHeaderComponent={ListHeader(headerHeight, totalHits)}
       ListFooterComponent={ListFooter}
       //this rerenders the list every time there is a change in the screen width
-      key={`id${screenWidth}`}
+      key={screenOrientation}
       onScroll={(e) => onScroll(e)}
       getItemLayout={getItemLayout}
       data={parsed}
@@ -97,7 +101,11 @@ const ImageList = ({
           <Image
             resizeMode="cover"
             source={{ uri: item.previewURL }}
-            style={[styles.roundedBorder, styles.imageThumbnail]}
+            style={[
+              styles.roundedBorder,
+              styles.imageThumbnail,
+              { height: imageWidthandHeight, width: imageWidthandHeight },
+            ]}
           />
         </TouchableOpacity>
       )}
@@ -119,6 +127,7 @@ ImageList.propTypes = {
   results: PropTypes.string.isRequired,
   totalHits: PropTypes.number.isRequired,
   screenWidth: PropTypes.number.isRequired,
+  screenOrientation: PropTypes.string.isRequired,
 };
 
 export default connect()(ImageList);

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -5,7 +5,13 @@ import { View, Text } from "react-native";
 import PropTypes from "prop-types";
 
 // The SearchResults Component displays either an ImageList or text showing no results
-const SearchResults = ({ navigation, results, totalHits, screenWidth }) => {
+const SearchResults = ({
+  navigation,
+  results,
+  totalHits,
+  screenWidth,
+  screenOrientation,
+}) => {
   return (
     <View style={[styles.flexOne, styles.margin]}>
       {/* if there are any hits render the ImageList */}
@@ -15,6 +21,7 @@ const SearchResults = ({ navigation, results, totalHits, screenWidth }) => {
           results={results}
           totalHits={totalHits}
           screenWidth={screenWidth}
+          screenOrientation={screenOrientation}
         />
       ) : (
         <Text style={styles.infoText}>
@@ -31,6 +38,7 @@ SearchResults.propTypes = {
   results: PropTypes.string,
   totalHits: PropTypes.number,
   screenWidth: PropTypes.number.isRequired,
+  screenOrientation: PropTypes.string.isRequired,
 };
 
 export default SearchResults;

--- a/src/containers/SearchResultsContainer.js
+++ b/src/containers/SearchResultsContainer.js
@@ -9,6 +9,7 @@ const mapStateToProps = (state) => {
       : state.searchResults.hits,
     totalHits: state.searchResults.totalHits,
     screenWidth: state.screenDimensions.screenWidth,
+    screenOrientation: state.screenDimensions.screenOrientation,
   };
 };
 

--- a/src/screens/DetailsScreen.js
+++ b/src/screens/DetailsScreen.js
@@ -62,7 +62,7 @@ const DetailsScreen = ({ route, navigation, screenDimensions }) => {
 DetailsScreen.propTypes = {
   route: PropTypes.object.isRequired,
   navigation: PropTypes.object.isRequired,
-  screenDimension: PropTypes.shape({
+  screenDimensions: PropTypes.shape({
     screenWidth: PropTypes.number.isRequired,
     screenHeight: PropTypes.number.isRequired,
     screenOrientation: PropTypes.string.isRequired,

--- a/src/screens/DetailsScreen.js
+++ b/src/screens/DetailsScreen.js
@@ -25,13 +25,20 @@ const DetailsScreen = ({ route, navigation, screenDimensions }) => {
     image.webformatHeight
   );
 
+  //for larger screens, like tablets, if the image is larger than the webformatURL, use the largeImageURL.
+  const displayURL =
+    imageDimensions.width <= image.webformatWidth &&
+    imageDimensions.height <= image.webformatHeight
+      ? "webformatURL"
+      : "largeImageURL";
+
   return (
     <View style={[containerStyle, styles.flexOne, styles.margin]}>
       <View style={styles.flexColumn}>
         <Image
           resizeMode="cover"
           key={`id${image.id}`}
-          source={{ uri: image.webformatURL }}
+          source={{ uri: image[displayURL] }}
           style={[
             styles.roundedBorder,
             styles.margin,

--- a/src/style/appStyles.js
+++ b/src/style/appStyles.js
@@ -69,8 +69,6 @@ const text = {
 //image styles
 const images = {
   imageThumbnail: {
-    width: 85,
-    height: 85,
     margin: theme.space[1],
   },
 };

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -99,16 +99,6 @@ export const calculateImageDisplayDimensions = (
   return { width: imageWidth, height: imageHeight };
 };
 
-//calculate the number of columns that should be shown in the image list
-export const calculateImageListColumns = (screenWidth, marginInPixels) => {
-  //calcuate imageWidth using stylesheet
-  imageWidth = styles.imageThumbnail.width + styles.imageThumbnail.margin;
-  //get the width of the screen from the redux store, subtrack the width of the side margin
-  const availableWidth = screenWidth - 2 * marginInPixels;
-  //return how many columns can fit
-  return Math.floor(availableWidth / imageWidth);
-};
-
 //calculate the size of the image thumbnail in the imageList
 export const calculateImageThumbnailWidthandHeight = (
   screenWidth,

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -108,3 +108,20 @@ export const calculateImageListColumns = (screenWidth, marginInPixels) => {
   //return how many columns can fit
   return Math.floor(availableWidth / imageWidth);
 };
+
+//calculate the size of the image thumbnail in the imageList
+export const calculateImageThumbnailWidthandHeight = (
+  screenWidth,
+  screenOrientation,
+  marginInPixels
+) => {
+  //get imageMargin from stylesheet
+  const imageMargin = styles.imageThumbnail.margin;
+  //subtract the width of the side margin from the screenWidth
+  const availableWidth = screenWidth - 2 * marginInPixels;
+  //There should be 4 columns in portrait and 8 in landscape
+  numColumns = screenOrientation == "portrait" ? 4 : 8;
+  imageWidth = Math.floor(availableWidth / numColumns);
+  //return the width of the image including margins
+  return imageWidth - 2 * imageMargin;
+};


### PR DESCRIPTION
The goal of this PR is to change the way the list image works. All portrait screens will now have 4 columns and all landscape screens it'll have 8 columns. The image thumbnail width is calculated based on the screen width. This will prevent the grid from jumping around when screen orientation is changed. 